### PR TITLE
Add M dwarf spectral defaults and mask selection

### DIFF
--- a/src/yarara/sts/__init__.py
+++ b/src/yarara/sts/__init__.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import glob as glob
+import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, TypedDict
+from typing import Any, Dict, Optional, Set, Tuple, TypedDict, cast
 
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
 
 from ..iofun import pickle_dump
+from .star_type import (
+    apply_spectral_type_defaults,
+    create_default_star_info,
+    select_ccf_mask,
+)
 
 
 class SIF_float_telluric(TypedDict, total=False):
@@ -306,38 +312,7 @@ class spec_time_series(object):
             os.system("mkdir " + self.dir_root + "STAR_INFO/")
 
         if not os.path.exists(self.dir_root + "STAR_INFO/Stellar_info_" + self.starname + ".p"):
-            dico: StarInfo = {
-                "Name": self.starname,
-                "Simbad_name": {"fixed": "-"},
-                "Sp_type": {"fixed": "G2V"},
-                "Ra": {"fixed": "00 00 00.0000"},
-                "Dec": {"fixed": "00 00 00.0000"},
-                "Pma": {"fixed": 0.0},
-                "Pmd": {"fixed": 0.0},
-                "Rv_sys": {"fixed": 0.0},
-                "Mstar": {"fixed": 1.0},
-                "Rstar": {"fixed": 1.0},
-                "magU": {"fixed": -26.0},
-                "magB": {"fixed": -26.2},
-                "magV": {"fixed": -26.8},
-                "magR": {"fixed": -26.8},
-                "UB": {"fixed": 0.0},
-                "BV": {"fixed": 0.6},
-                "VR": {"fixed": 0.0},
-                "Dist_pc": {"fixed": 0.0},
-                "Teff": {"fixed": 5775},
-                "Log_g": {"fixed": 4.5},
-                "FeH": {"fixed": 0.0},
-                "Vsini": {"fixed": 2.0},
-                "Vmicro": {"fixed": 1.0},
-                "Prot": {"fixed": 25},
-                "Pmag": {"fixed": 11},
-                "FWHM": {"fixed": 6.0},
-                "Contrast": {"fixed": 0.5},
-                "CCF_delta": {"fixed": 5},
-                "stellar_template": {"fixed": "MARCS_T5750_g4.5"},
-            }
-
+            dico = create_default_star_info(self.starname)
             pickle_dump(
                 dico,
                 open(
@@ -347,8 +322,7 @@ class spec_time_series(object):
             )
 
         self.import_star_info()
-        sp = self.star_info["Sp_type"]["fixed"][0]
-        self.mask_harps = ["G2", "K5", "M2"][int((sp == "K") | (sp == "M")) + int(sp == "M")]
+        self._refresh_star_type_configuration()
         if "YARARA" in self.star_info["FWHM"]:
             self.fwhm = self.star_info["FWHM"]["YARARA"]
         else:
@@ -468,3 +442,35 @@ class spec_time_series(object):
 
         # from yarara_check_fwhm
         self.warning_rv_borders: bool = None  # type: ignore
+
+    def _available_ccf_masks(self) -> Set[str]:
+        return {mask.stem for mask in self.mask_ccf_folder.glob("*.txt")}
+
+    def _update_mask_from_star_info(self) -> None:
+        sp_type_entry = self.star_info.get("Sp_type", {})
+        if isinstance(sp_type_entry, dict):
+            sp_type_value = cast(Optional[str], sp_type_entry.get("fixed"))
+        else:
+            sp_type_value = cast(Optional[str], sp_type_entry)
+
+        available_masks = self._available_ccf_masks()
+        try:
+            mask, desired_mask = select_ccf_mask(sp_type_value, available_masks)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"No CCF mask files found in {self.mask_ccf_folder}"
+            ) from exc
+
+        if mask != desired_mask:
+            logging.warning(
+                "CCF mask '%s' not available; using '%s' for spectral type '%s'.",
+                desired_mask,
+                mask,
+                sp_type_value or "unknown",
+            )
+
+        self.mask_harps = mask
+
+    def _refresh_star_type_configuration(self) -> None:
+        apply_spectral_type_defaults(self.star_info)
+        self._update_mask_from_star_info()

--- a/src/yarara/sts/_bridge/__init__.py
+++ b/src/yarara/sts/_bridge/__init__.py
@@ -48,13 +48,12 @@ def yarara_simbad_query(self: spec_time_series, starname=None) -> None:
                 for kw2 in dico2[kw].keys():
                     dico[kw][kw2] = dico2[kw][kw2]
 
+    self._refresh_star_type_configuration()
+
     pickle_dump(
         dico,
         open(self.dir_root + "STAR_INFO/Stellar_info_" + self.starname + ".p", "wb"),
     )
-
-    sp = dico["Sp_type"]["fixed"]
-    self.mask_harps = ["G2", "K5", "M2"][int((sp[0] == "K") | (sp[0] == "M")) + int(sp[0] == "M")]
 
     del dico["Name"]
 

--- a/src/yarara/sts/star_type.py
+++ b/src/yarara/sts/star_type.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any, Collection, Dict, Optional, Tuple, TYPE_CHECKING, cast
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from . import StarInfo
+
+
+_DEFAULT_STAR_INFO_FIXED_VALUES: Dict[str, Any] = {
+    "Simbad_name": "-",
+    "Sp_type": "G2V",
+    "Ra": "00 00 00.0000",
+    "Dec": "00 00 00.0000",
+    "Pma": 0.0,
+    "Pmd": 0.0,
+    "Rv_sys": 0.0,
+    "Mstar": 1.0,
+    "Rstar": 1.0,
+    "magU": -26.0,
+    "magB": -26.2,
+    "magV": -26.8,
+    "magR": -26.8,
+    "UB": 0.0,
+    "BV": 0.6,
+    "VR": 0.0,
+    "Dist_pc": 0.0,
+    "Teff": 5775,
+    "Log_g": 4.5,
+    "FeH": 0.0,
+    "Vsini": 2.0,
+    "Vmicro": 1.0,
+    "Prot": 25,
+    "Pmag": 11,
+    "FWHM": 6.0,
+    "Contrast": 0.5,
+    "CCF_delta": 5,
+    "stellar_template": "MARCS_T5750_g4.5",
+}
+
+
+_SPECTRAL_CLASS_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "K": {
+        "Mstar": 0.8,
+        "Rstar": 0.8,
+        "Teff": 4800,
+        "Log_g": 4.6,
+        "FWHM": 5.5,
+        "Contrast": 0.45,
+        "stellar_template": "MARCS_T4750_g4.5",
+    },
+    "M": {
+        "Mstar": 0.35,
+        "Rstar": 0.35,
+        "Teff": 3550,
+        "Log_g": 5.0,
+        "FWHM": 4.3,
+        "Contrast": 0.35,
+        "stellar_template": "MARCS_T3500_g5.0",
+    },
+}
+
+
+_DEFAULT_MASK_BY_CLASS: Dict[str, str] = {
+    "O": "G2",
+    "B": "G2",
+    "A": "G2",
+    "F": "G2",
+    "G": "G2",
+    "K": "K5",
+    "M": "M2",
+}
+
+
+_MASK_FALLBACKS: Dict[str, Tuple[str, ...]] = {
+    "G2": ("K5", "M2"),
+    "K5": ("G2", "M2"),
+    "M2": ("K5", "G2"),
+}
+
+
+def create_default_star_info(starname: str) -> "StarInfo":
+    star_info: "StarInfo" = {"Name": starname}
+    for key, value in _DEFAULT_STAR_INFO_FIXED_VALUES.items():
+        star_info[key] = cast(Dict[str, Any], {"fixed": value})
+    return star_info
+
+
+def _spectral_class_from_type(sp_type: Optional[str]) -> str:
+    if not sp_type:
+        return "G"
+    for char in sp_type.upper():
+        if char.isalpha():
+            return char
+    return "G"
+
+
+def apply_spectral_type_defaults(star_info: "StarInfo") -> None:
+    sp_type_entry = star_info.get("Sp_type")
+    sp_type_value: Optional[str]
+    if isinstance(sp_type_entry, dict):
+        sp_type_value = cast(Optional[str], sp_type_entry.get("fixed"))
+    else:
+        sp_type_value = cast(Optional[str], sp_type_entry)
+
+    spectral_class = _spectral_class_from_type(sp_type_value)
+    overrides = _SPECTRAL_CLASS_DEFAULTS.get(spectral_class)
+    if overrides is None:
+        return
+
+    for field, value in overrides.items():
+        container = cast(Dict[str, Any], star_info.setdefault(field, {}))
+        current_value = container.get("fixed")
+        default_value = _DEFAULT_STAR_INFO_FIXED_VALUES.get(field)
+        if current_value is None or current_value == default_value:
+            container["fixed"] = value
+
+
+def _determine_ccf_mask(desired_mask: str, available_masks: Collection[str]) -> str:
+    if desired_mask in available_masks:
+        return desired_mask
+
+    for fallback in _MASK_FALLBACKS.get(desired_mask, ()):
+        if fallback in available_masks:
+            return fallback
+
+    if available_masks:
+        return sorted(set(available_masks))[0]
+
+    raise FileNotFoundError("No CCF mask files available")
+
+
+def select_ccf_mask(sp_type: Optional[str], available_masks: Collection[str]) -> Tuple[str, str]:
+    spectral_class = _spectral_class_from_type(sp_type)
+    desired_mask = _DEFAULT_MASK_BY_CLASS.get(spectral_class, "G2")
+    mask = _determine_ccf_mask(desired_mask, available_masks)
+    return mask, desired_mask

--- a/tests/test_spectral_type_defaults.py
+++ b/tests/test_spectral_type_defaults.py
@@ -1,0 +1,60 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "src" / "yarara" / "sts" / "star_type.py"
+spec = importlib.util.spec_from_file_location("yarara_star_type", MODULE_PATH)
+star_type = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = star_type
+assert spec.loader is not None
+spec.loader.exec_module(star_type)
+
+apply_spectral_type_defaults = star_type.apply_spectral_type_defaults
+create_default_star_info = star_type.create_default_star_info
+select_ccf_mask = star_type.select_ccf_mask
+
+
+def test_apply_defaults_for_m_dwarf_updates_expected_fields():
+    star_info = create_default_star_info("TestStar")
+    star_info["Sp_type"]["fixed"] = "M4V"
+
+    apply_spectral_type_defaults(star_info)
+
+    assert star_info["Teff"]["fixed"] == 3550
+    assert star_info["Log_g"]["fixed"] == 5.0
+    assert star_info["Mstar"]["fixed"] == 0.35
+    assert star_info["Rstar"]["fixed"] == 0.35
+    assert star_info["FWHM"]["fixed"] == 4.3
+    assert star_info["Contrast"]["fixed"] == 0.35
+    assert star_info["stellar_template"]["fixed"] == "MARCS_T3500_g5.0"
+
+
+def test_apply_defaults_keeps_user_values():
+    star_info = create_default_star_info("AnotherStar")
+    star_info["Sp_type"]["fixed"] = "M2V"
+    star_info["FWHM"]["fixed"] = 5.1
+
+    apply_spectral_type_defaults(star_info)
+
+    assert star_info["FWHM"]["fixed"] == 5.1
+
+
+def test_select_mask_prefers_available_m_dwarf_mask():
+    mask, desired = select_ccf_mask("M3V", {"M2", "K5", "G2"})
+
+    assert desired == "M2"
+    assert mask == "M2"
+
+
+def test_select_mask_falls_back_to_k_when_m_mask_missing():
+    mask, desired = select_ccf_mask("M5V", {"K5", "G2"})
+
+    assert desired == "M2"
+    assert mask == "K5"
+
+
+def test_select_mask_requires_at_least_one_mask():
+    with pytest.raises(FileNotFoundError):
+        select_ccf_mask("M1V", set())


### PR DESCRIPTION
## Summary
- centralize star metadata defaults and mask selection in a new star_type helper module
- update spec_time_series initialization and SIMBAD import to apply M-dwarf friendly defaults and mask fallbacks
- add unit tests covering M-dwarf defaults and mask selection behaviour

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_spectral_type_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68cf82b07dbc8331a4a49bca1d41acc7